### PR TITLE
Fix for  vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "async": "~1.5.2",
     "debug": "~2.2.0",
     "lodash": "~3.9.3",
-    "request": "~2.69.0",
+    "request": "~2.74.0",
     "uuid": "~2.0.1",
     "winston": "~2.2.0",
     "winston-daily-rotate-file": "~1.0.1"


### PR DESCRIPTION
microgateway-core currently has a vulnerable dependency, introducing [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.
You can see [Snyk test report](https://snyk.io/test/github/apigee/microgateway-core) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, which uses the fixed `tough-cookie` version 2.3.1, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Community.
